### PR TITLE
Fix caching bug

### DIFF
--- a/carbon14/django.py
+++ b/carbon14/django.py
@@ -50,7 +50,7 @@ class ModelCollection(Collection):
         else:
             if ids is not None:
                 instances = instances.filter(id__in=ids)
-        return instances
+        return instances.all()
 
 
 class GraphQLView(APIView):

--- a/carbon14/neonode.py
+++ b/carbon14/neonode.py
@@ -98,7 +98,7 @@ class Collection(metaclass=Node):
     def _to_value(
             self, collection_name, level, instances=..., children=None,
             **kwargs):
-        instances = self._source if instances is ... else instances
+        instances = self._source.all() if instances is ... else instances
         children = children or {}
         children.setdefault('id', {'parameters': {}, 'children': {}})
 

--- a/carbon14/neonode.py
+++ b/carbon14/neonode.py
@@ -98,7 +98,7 @@ class Collection(metaclass=Node):
     def _to_value(
             self, collection_name, level, instances=..., children=None,
             **kwargs):
-        instances = self._source.all() if instances is ... else instances
+        instances = self._source if instances is ... else instances
         children = children or {}
         children.setdefault('id', {'parameters': {}, 'children': {}})
 


### PR DESCRIPTION
The call to `all()` prevents the queryset from being cached between subsequent calls to the API.

https://docs.djangoproject.com/en/1.11/ref/models/querysets/#django.db.models.query.QuerySet.all