### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/carbon14/django.py
+++ b/carbon14/django.py
@@ -54,7 +54,7 @@ class ModelCollection(Collection):
             offset=0,
             **kwargs
     ):
-        if self._auth_required and not ctx.user.is_authenticated():
+        if self._auth_required and not ctx.user.is_authenticated:
             instances = instances.none()
         else:
             if ids is not None:


### PR DESCRIPTION
From [Django 2.0 changelog](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0), you see they removed the method call to `is_authenticated`, now they want you to use it as a property.

> Using User.is_authenticated() and User.is_anonymous() as methods rather than properties is no longer supported.
